### PR TITLE
Fix issue when first command is sent

### DIFF
--- a/rallyrobopilot/car.py
+++ b/rallyrobopilot/car.py
@@ -65,6 +65,11 @@ class Car(Entity):
         self.particle_pivot = Entity(parent = self)
         self.particle_pivot.position = (0, -1, -2)
 
+        # Load the particles when initializing the car to avoid a lag the first time the forward input is pressed
+        self.particle_time = 0
+        self.particles = Particles(self, self.particle_pivot.world_position - (0, 1, 0))
+        self.particles.destroy(1)
+
         # TrailRenderer
         self.trail_pivot = Entity(parent = self, position = (0, -1, 2))
 

--- a/rallyrobopilot/car.py
+++ b/rallyrobopilot/car.py
@@ -66,7 +66,6 @@ class Car(Entity):
         self.particle_pivot.position = (0, -1, -2)
 
         # Load the particles when initializing the car to avoid a lag the first time the forward input is pressed
-        self.particle_time = 0
         self.particles = Particles(self, self.particle_pivot.world_position - (0, 1, 0))
         self.particles.destroy(1)
 


### PR DESCRIPTION
Load the particles when init the car to avoid a lag when the first key is pressed, causing the car to not drive well